### PR TITLE
update from upstream

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -144,8 +144,8 @@ branches:
             app_id: 15368
           - context: "Format"
             app_id: 15368
-          - context: "codecov/project"
-            app_id: 254
+          # - context: "codecov/project"
+          #   app_id: 254
       # Commits pushed to matching refs must have verified signatures.
       required_signatures: false
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -29,33 +29,6 @@ jobs:
           show-progress: false
           fetch-depth: 0
 
-      - name: Cache dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        env:
-          CACHE_NAME: cargo-cache-dependencies
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-cocogitto
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-
-            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-
-
-      - name: Set up toolchain
-        shell: bash
-        run: |
-          rm ${HOME}/.cargo/bin/cargo-fmt
-          rm ${HOME}/.cargo/bin/rust-analyzer
-          rm ${HOME}/.cargo/bin/rustfmt
-
-          rustup self update
-          rustup update
-          rustup show active-toolchain || rustup toolchain install
-          rustup show
-
-          cargo --version
-
       - name: Get binstall
         shell: bash
         working-directory: /tmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
- **chore(deps): update @types/node (npm) to v22.17.0**
- **chore(deps): update github/codeql-action action to v3.29.5**
- **chore(deps): update github/codeql-action action to v3.29.5**
- **chore(deps): update react monorepo**
- **chore(deps): update vite-plugin-checker (npm) to v0.10.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.131.0**
- **chore(deps): update pnpm to v10.14.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.131.0**
- **chore(deps): update pnpm to v10.14.0**
- **chore(deps): update typescript (npm) to v5.9.2**
- **chore(deps): update node.js to v22.18.0**
- **chore(deps): update node.js to v22.18.0**
- **chore(deps): update docker/metadata-action action to v5.8.0**
- **chore(deps): update docker/metadata-action action to v5.8.0**
- **fix(deps): update rust crate tokio to 1.47.1**
- **chore: don't cache in lint-configs**
- **fix(deps): update rust crate tokio-util to 0.7.16**
- **chore: disable codecov, fails too often**
