### PR TITLE
update from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Rust toolchain setup
-FROM --platform=${BUILDPLATFORM} rust:1.89.0@sha256:6e6d04bd50cd4c433a805c58c13f186a508c5b5417b9b61cae40ec28e0593c51 AS rust-base
+FROM --platform=${BUILDPLATFORM} rust:1.89.0-trixie@sha256:6e6d04bd50cd4c433a805c58c13f186a508c5b5417b9b61cae40ec28e0593c51 AS rust-base
 
 ARG APPLICATION_NAME
 
@@ -14,8 +14,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     && apt-get upgrade --yes \
     && apt-get install --no-install-recommends --yes \
         build-essential \
-        musl-dev \
-        musl-tools
+        musl-dev
 
 FROM rust-base AS rust-linux-amd64
 ARG TARGET=x86_64-unknown-linux-musl

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -7,13 +7,13 @@ cpp_compiler="g++"
 rust_flags="-Clink-self-contained=yes -Clinker=rust-lld --cfg tokio_unstable"
 
 case $TARGET in
-    x86_64-unknown-linux-*)
-        c_compiler="x86_64-linux-gnu-gcc-12"
-        cpp_compiler="x86_64-linux-gnu-g++-12"
+    x86_64-unknown-linux-musl)
+        c_compiler="x86_64-linux-musl-gcc"
+        cpp_compiler="x86_64-linux-musl-g++"
         ;;
-    aarch64-unknown-linux-*)
-        c_compiler="aarch64-linux-gnu-gcc"
-        cpp_compiler="aarch64-linux-gnu-g++"
+    aarch64-unknown-linux-musl)
+        c_compiler="aarch64-linux-musl-gcc"
+        cpp_compiler="aarch64-linux-musl-g++"
         ;;
     *)
         echo "INVALID CONFIGURATION"

--- a/build-scripts/setup-env.sh
+++ b/build-scripts/setup-env.sh
@@ -7,9 +7,7 @@ dpkg_add_arch() {
     fi
     apt-get update
     apt-get --no-install-recommends install --yes \
-        binutils-$2-linux-gnu \
-        gcc-$2-linux-gnu \
-        g++-$2-linux-gnu
+        musl-tools:$1
 }
 
 case $TARGET in


### PR DESCRIPTION
- **chore(deps): update typescript-eslint monorepo to v8.40.0**
- **chore(deps): update @vitejs/plugin-react (npm) to v5.0.1**
- **chore(deps): update vite (npm) to v7.1.3**
- **chore(deps): update pnpm to v10.15.0**
- **chore(deps): update rust:1.89.0 docker digest to 6e6d04b**
- **chore(deps): update pnpm to v10.15.0**
- **chore(deps): update rust:1.89.0 docker digest to 6e6d04b**
- **feat: pin to trixie, use gcc-14 from trixie**
- **chore: use musl all the way**
