### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
       - name: Set up node
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: package.json
           cache: pnpm

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,16 @@
     "lldb.launch.expressions": "simple",
     "lldb.launch.terminal": "integrated",
     "prettier.configPath": "./prettier.config.mjs",
+    "rust-analyzer.cargo.extraEnv": {
+        // "RUSTC_BOOTSTRAP": "1"
+    },
+    "rust-analyzer.cargo.features": [],
     "rust-analyzer.runnables.extraEnv": {
+        // "RUSTC_BOOTSTRAP": "1",
         "FRONT_END_PROXY": "127.0.0.1:4000",
         "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,endless_ssh_rs_with_web=TRACE,tower_http::trace=TRACE"
     },
+    "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
     "typescript.preferences.importModuleSpecifier": "non-relative",
     "typescript.preferences.importModuleSpecifierEnding": "js",
     "typescript.tsdk": "node_modules/typescript/lib"

--- a/generate-test-report.sh
+++ b/generate-test-report.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+BASE_RUSTFLAGS=""
+CARGO_FEATURES=""
+
+export RUSTFLAGS="${BASE_RUSTFLAGS} --allow=warnings -Cinstrument-coverage"
+# build-* ones are not parsed by grcov
+export LLVM_PROFILE_FILE="profiling/build-%p-%m.profraw"
+
+cargo build ${CARGO_FEATURES} --all-targets --locked --workspace --verbose
+
+# different
+LLVM_PROFILE_FILE="profiling/profile-%p-%m.profraw"
+cargo nextest run --profile ci --no-fail-fast ${CARGO_FEATURES} --all-targets --workspace
+
+grcov $(find . -name "profile-*.profraw" -print) \
+    --binary-path ./target/debug/ \
+    --branch \
+    --ignore-not-existing \
+    --keep-only "src/**" \
+    --llvm \
+    --output-type html \
+    --output-path ./reports/ \
+    --source-dir .


### PR DESCRIPTION
- **chore(deps): update github/codeql-action action to v4**
- **chore(deps): update pnpm to v10.18.1**
- **chore(deps): update softprops/action-gh-release action to v2.4.0**
- **chore(deps): update pnpm/action-setup action to v4.2.0**
- **chore(deps): update alpine docker tag to v3.22.2**
- **chore(deps): update registry:3 docker digest to 1e96c37**
- **chore(deps): update node.js to v24.10.0**
- **chore(deps): update registry:3 docker digest to f1d6d55**
- **chore(deps): update registry:3 docker digest to 491add1**
- **chore(deps): lock file maintenance**
- **chore(deps): update pnpm to v10.18.2**
- **chore(deps): update github/codeql-action action to v4.30.8**
- **chore(deps): update registry:3 docker digest to cd92709**
- **chore: test script for local coverage display**
- **chore: fmt**
- **chore(deps): update softprops/action-gh-release action to v2.4.1**
- **chore(ci): enforce nightly fmt**
- **chore(ci): kill enforcement of nightly fmt**
- **chore(deps): update actions/setup-node action to v6**
- **chore: full (semantic) version**
- **chore(deps): update pnpm to v10.18.3**
