### PR TITLE
update from upstream

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,22 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Debug executable 'endless-ssh-rs-with-web'",
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'endless-ssh-rs'",
             "cargo": {
-                "args": [
-                    "build",
-                    "--bin=endless-ssh-rs",
-                    "--package=endless-ssh-rs"
-                ],
-                "filter": {
-                    "name": "endless-ssh-rs",
-                    "kind": "bin"
-                }
+                "args": ["run", "--bin=endless-ssh-rs-with-web"]
             },
             "args": [],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,endless_ssh_rs_with_web=TRACE,tower_http::trace=TRACE"
@@ -29,22 +20,13 @@
             "terminal": "integrated"
         },
         {
+            "name": "Debug executable 'endless-ssh-rs-with-web' wrong-params",
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'endless-ssh-rs' wrong-params",
             "cargo": {
-                "args": [
-                    "build",
-                    "--bin=endless-ssh-rs",
-                    "--package=endless-ssh-rs"
-                ],
-                "filter": {
-                    "name": "endless-ssh-rs",
-                    "kind": "bin"
-                }
+                "args": ["run", "--bin=endless-ssh-rs-with-web"]
             },
             "args": ["wrong-params"],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,endless_ssh_rs_with_web=TRACE,tower_http::trace=TRACE"
@@ -53,22 +35,13 @@
             "terminal": "integrated"
         },
         {
+            "name": "Debug executable 'endless-ssh-rs-with-web' help",
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'endless-ssh-rs' help",
             "cargo": {
-                "args": [
-                    "build",
-                    "--bin=endless-ssh-rs",
-                    "--package=endless-ssh-rs"
-                ],
-                "filter": {
-                    "name": "endless-ssh-rs",
-                    "kind": "bin"
-                }
+                "args": ["run", "--bin=endless-ssh-rs-with-web"]
             },
             "args": ["-h"],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,endless_ssh_rs_with_web=TRACE,tower_http::trace=TRACE"
@@ -77,23 +50,13 @@
             "terminal": "integrated"
         },
         {
+            "name": "Debug unit tests in executable 'endless-ssh-rs-with-web'",
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in executable 'endless-ssh-rs'",
             "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--bin=endless-ssh-rs",
-                    "--package=endless-ssh-rs"
-                ],
-                "filter": {
-                    "name": "endless-ssh-rs",
-                    "kind": "bin"
-                }
+                "args": ["test", "--no-run", "--bin=endless-ssh-rs-with-web"]
             },
             "args": [],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,endless_ssh_rs_with_web=TRACE,tower_http::trace=TRACE"
@@ -102,23 +65,13 @@
             "terminal": "integrated"
         },
         {
-            "type": "lldb",
-            "request": "launch",
             "name": "Debug integration test 'integration_tests'",
+            "type": "lldb",
+            "request": "launch",
             "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--test=integration_tests",
-                    "--package=endless-ssh-rs"
-                ],
-                "filter": {
-                    "name": "integration_tests",
-                    "kind": "test"
-                }
+                "args": ["test", "--no-run", "--test=integration_tests"]
             },
             "args": [],
-            "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,socketioxide=INFO,engineioxide=INFO,endless_ssh_rs_with_web=TRACE,tower_http::trace=TRACE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["fun"]
 keywords = ["random"]
 repository = "https://github.com/kristof-mattei/endless-ssh-rs"
 include = ["src/**", "/LICENSE", "/LICENSE-*"]
+build = "back-end/src/build.rs"
 
 [[bin]]
 name = "endless-ssh-rs-with-web"
@@ -63,23 +64,16 @@ style = "warn"
 suspicious = "warn"
 
 # restriction
-
+absolute_paths = { level = "deny", priority = 127 }
 # Lib only
 # alloc_instead_of_core = { level = "deny", priority = 127 }
-# std_instead_of_alloc = { level = "deny", priority = 127 }
-# std_instead_of_core = { level = "deny", priority = 127 }
-# exhaustive_enums = { level = "deny", priority = 127 }
-# exhaustive_structs = { level = "deny", priority = 127 }
-# empty_enum_variants_with_brackets = { level = "deny", priority = 127 }
-# empty_structs_with_brackets = { level = "deny", priority = 127 }
-# missing_inline_in_public_items = { level = "deny", priority = 127 }
-
-absolute_paths = { level = "deny", priority = 127 }
 allow_attributes = { level = "deny", priority = 127 }
 allow_attributes_without_reason = { level = "deny", priority = 127 }
+# No
+# arbitrary_source_item_ordering = { level = "deny", priority = 127 }
 # Debatable
 # arithmetic_side_effects = { level = "deny", priority = 127 }
-# Debatable
+# Debatable, the ones below deny more specific occurences
 # as_conversions = { level = "deny", priority = 127 }
 as_pointer_underscore = { level = "deny", priority = 127 }
 as_underscore = { level = "deny", priority = 127 }
@@ -88,38 +82,57 @@ big_endian_bytes = { level = "deny", priority = 127 }
 cfg_not_test = { level = "deny", priority = 127 }
 # ensure we do Arc::clone(&arc) instead of arc.clone()
 clone_on_ref_ptr = { level = "deny", priority = 127 }
+# No
+# cognitive_complexity = { level = "deny", priority = 127 }
 create_dir = { level = "deny", priority = 127 }
 dbg_macro = { level = "deny", priority = 127 }
 decimal_literal_representation = { level = "deny", priority = 127 }
-# Debatable
+# No, false positives / false negatives
 # default_numeric_fallback = { level = "deny", priority = 127 }
 default_union_representation = { level = "deny", priority = 127 }
 deref_by_slicing = { level = "deny", priority = 127 }
+# No, we already have `non_ascii_idents` which is even bette
+# disallowed_script_idents = { level = "deny", priority = 127 }
 doc_include_without_cfg = { level = "deny", priority = 127 }
 else_if_without_else = { level = "deny", priority = 127 }
 empty_drop = { level = "deny", priority = 127 }
+# Lib only
+# empty_enum_variants_with_brackets = { level = "deny", priority = 127 }
+# Lib only
+# empty_structs_with_brackets = { level = "deny", priority = 127 }
 error_impl_error = { level = "deny", priority = 127 }
+# Lib only
+# exhaustive_enums = { level = "deny", priority = 127 }
+# Lib only
+# exhaustive_structs = { level = "deny", priority = 127 }
 exit = { level = "deny", priority = 127 }
+# No, unwrap (or expect) is information to the reader
+# expect_used = { level = "deny", priority = 127 }
 field_scoped_visibility_modifiers = { level = "deny", priority = 127 }
 filetype_is_file = { level = "deny", priority = 127 }
 # Debatable
 # float_arithmetic = { level = "deny", priority = 127 }
 float_cmp_const = { level = "deny", priority = 127 }
 fn_to_numeric_cast_any = { level = "deny", priority = 127 }
-# Debatable
+# No, `.get().unwrap()` is more explicit than []. This is not about `.get().expect()`
 # get_unwrap = { level = "deny", priority = 127 }
 host_endian_bytes = { level = "deny", priority = 127 }
 # Debatable
 # if_then_some_else_none = { level = "deny", priority = 127 }
 impl_trait_in_params = { level = "deny", priority = 127 }
-# Debatable
+# We want implicit return
+# implicit_return = { level = "deny", priority = 127 }
+# Debatable, but probably should be turned on in the future
 # indexing_slicing = { level = "deny", priority = 127 }
 infinite_loop = { level = "deny", priority = 127 }
 inline_asm_x86_att_syntax = { level = "deny", priority = 127 }
+# We want intel
+# inline_asm_x86_intel_syntax = { level = "deny", priority = 127 }
 # Debatable
 # integer_division = { level = "deny", priority = 127 }
 # Debatable
 # integer_division_remainder_used = { level = "deny", priority = 127 }
+iter_over_hash_type = { level = "deny", priority = 127 }
 large_include_file = { level = "deny", priority = 127 }
 let_underscore_must_use = { level = "deny", priority = 127 }
 let_underscore_untyped = { level = "deny", priority = 127 }
@@ -128,7 +141,18 @@ lossy_float_literal = { level = "deny", priority = 127 }
 # Debatable
 # map_err_ignore = { level = "deny", priority = 127 }
 map_with_unused_argument_over_ranges = { level = "deny", priority = 127 }
+mem_forget = { level = "deny", priority = 127 }
+# Debatable
+# min_ident_chars = { level = "deny", priority = 127 }
 missing_assert_message = { level = "deny", priority = 127 }
+# Debatable
+# missing_asserts_for_indexing = { level = "deny", priority = 127 }
+# No
+# missing_docs_in_private_items = { level = "deny", priority = 127 }
+# Lib only
+# missing_inline_in_public_items = { level = "deny", priority = 127 }
+# No
+# missing_trait_methods = { level = "deny", priority = 127 }
 mixed_read_write_in_expression = { level = "deny", priority = 127 }
 mod_module_files = { level = "deny", priority = 127 }
 # Debatable
@@ -141,37 +165,64 @@ mutex_integer = { level = "deny", priority = 127 }
 needless_raw_strings = { level = "deny", priority = 127 }
 non_ascii_literal = { level = "deny", priority = 127 }
 non_zero_suggestions = { level = "deny", priority = 127 }
+# No
+# panic = { level = "deny", priority = 127 }
 panic_in_result_fn = { level = "deny", priority = 127 }
-# Debatable
-# partial_pub_fields = { level = "deny", priority = 127 }
+partial_pub_fields = { level = "deny", priority = 127 }
+# No, `.join()` does `.clone()`
+# pathbuf_init_then_push = { level = "deny", priority = 127 }
 pattern_type_mismatch = { level = "deny", priority = 127 }
+# No
+# pointer_format = { level = "deny", priority = 127 }
 precedence_bits = { level = "deny", priority = 127 }
 # Debatable
 # print_stderr = { level = "deny", priority = 127 }
 # Debatable
 # print_stdout = { level = "deny", priority = 127 }
+# Disable in libs
+pub_use = { level = "deny", priority = 127 }
+# No, we want the shorthand
+# pub_with_shorthand = { level = "deny", priority = 127 }
 pub_without_shorthand = { level = "deny", priority = 127 }
+# No
+# question_mark_used = { level = "deny", priority = 127 }
 rc_buffer = { level = "deny", priority = 127 }
 rc_mutex = { level = "deny", priority = 127 }
 redundant_test_prefix = { level = "deny", priority = 127 }
+# No, explicitness trumps brevity
+# redundant_type_annotations = { level = "deny", priority = 127 }
+# No, explicitness
+# ref_patterns = { level = "deny", priority = 127 }
 renamed_function_params = { level = "deny", priority = 127 }
 rest_pat_in_fully_bound_structs = { level = "deny", priority = 127 }
 return_and_then = { level = "deny", priority = 127 }
-# Debatable, need to think about it
+# Debatable, but probably should be turned on in the future
 # same_name_method = { level = "deny", priority = 127 }
+# No, we don't want `mod.rs`
+# self_named_module_files = { level = "deny", priority = 127 }
 semicolon_inside_block = { level = "deny", priority = 127 }
+# No, we want them outside, not inside
+# semicolon_outside_block = { level = "deny", priority = 127 }
+# No, we want them to be separated by `_`
+# separated_literal_suffix = { level = "deny", priority = 127 }
 # Debatable
 # shadow_reuse = { level = "deny", priority = 127 }
 # Debatable
 # shadow_same = { level = "deny", priority = 127 }
 # Debatable
 # shadow_unrelated = { level = "deny", priority = 127 }
+# No, clarity is important, also, this helps against binary bloat when doing monomorphization
+# single_call_fn = { level = "deny", priority = 127 }
+# No
+# single_char_lifetime_names = { level = "deny", priority = 127 }
+# Lib only
+# std_instead_of_alloc = { level = "deny", priority = 127 }
+# Lib only
+# std_instead_of_core = { level = "deny", priority = 127 }
 str_to_string = { level = "deny", priority = 127 }
 string_add = { level = "deny", priority = 127 }
 string_lit_chars_any = { level = "deny", priority = 127 }
-# Debatable, but no
-# string_slice = { level = "deny", priority = 127 }
-string_to_string = { level = "deny", priority = 127 }
+string_slice = { level = "deny", priority = 127 }
 suspicious_xor_used_as_pow = { level = "deny", priority = 127 }
 tests_outside_test_module = { level = "deny", priority = 127 }
 # Debatable
@@ -183,9 +234,17 @@ unnecessary_safety_comment = { level = "deny", priority = 127 }
 unnecessary_safety_doc = { level = "deny", priority = 127 }
 unnecessary_self_imports = { level = "deny", priority = 127 }
 unneeded_field_pattern = { level = "deny", priority = 127 }
+# No, this is information for the reader and compiler
+# unreachable = { level = "deny", priority = 127 }
 unseparated_literal_suffix = { level = "deny", priority = 127 }
 unused_result_ok = { level = "deny", priority = 127 }
 unused_trait_names = { level = "deny", priority = 127 }
+# No, unwrap (or expect) is information to the reader
+# unwrap_in_result = { level = "deny", priority = 127 }
+# No, unwrap (or expect) is information to the reader
+# unwrap_used = { level = "deny", priority = 127 }
+# No, we know that we shouldn't test on debug formats
+# use_debug  = { level = "deny", priority = 127 }
 verbose_file_reads = { level = "deny", priority = 127 }
 wildcard_enum_match_arm = { level = "deny", priority = 127 }
 
@@ -212,7 +271,7 @@ redundant_else = { level = "allow", priority = 127 }
 # this one causes confusion when combining variables (`foo`) and
 # dereferenced variables (`foo.bar`). The latter cannot be inlined
 # so we don't inline anything
-uninlined-format-args = { level = "allow", priority = 127 }
+uninlined_format_args = { level = "allow", priority = 127 }
 
 [lints.rust]
 let_underscore_drop = { level = "deny", priority = 127 }

--- a/back-end/src/build.rs
+++ b/back-end/src/build.rs
@@ -1,0 +1,46 @@
+use std::env;
+use std::ffi::OsStr;
+
+fn main() {
+    export_var(
+        "COMPILE_TIME_HOST",
+        &env::var("HOST").expect("HOST is set for build scripts"),
+    );
+    export_var(
+        "COMPILE_TIME_TARGET",
+        &env::var("TARGET").expect("TARGET is set for build scripts"),
+    );
+    export_var(
+        "COMPILE_TIME_TARGET_CPU",
+        &extract_target_cpu_from_rustflags(
+            &env::var_os("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default(),
+        )
+        .unwrap_or_default(),
+    );
+
+    println!("cargo:rerun-if-changed-env=HOST");
+    println!("cargo:rerun-if-changed-env=TARGET");
+    println!("cargo:rerun-if-changed-env=CARGO_ENCODED_RUSTFLAGS");
+}
+
+fn extract_target_cpu_from_rustflags(rustflags: &OsStr) -> Option<String> {
+    const ASCII_SEPARATOR: char = '\x1f';
+
+    let rustflags = rustflags.to_string_lossy();
+
+    let mut cpu = None;
+
+    for flag in rustflags.split(ASCII_SEPARATOR) {
+        let stripped_c = flag.strip_prefix("-C").unwrap_or(flag);
+
+        if let Some(target_cpu) = stripped_c.strip_prefix("target-cpu=") {
+            cpu = Some(target_cpu);
+        }
+    }
+
+    cpu.map(str::to_owned)
+}
+
+fn export_var(name: &str, value: &str) {
+    println!("cargo:rustc-env={}={}", name, value);
+}

--- a/back-end/src/build_env.rs
+++ b/back-end/src/build_env.rs
@@ -1,0 +1,48 @@
+pub const COMPILE_TIME_HOST: &str = env!("COMPILE_TIME_HOST");
+pub const COMPILE_TIME_TARGET: &str = env!("COMPILE_TIME_TARGET");
+pub const COMPILE_TIME_TARGET_CPU: Option<&str> = const {
+    let cttc = env!("COMPILE_TIME_TARGET_CPU");
+
+    if cttc.is_empty() { None } else { Some(cttc) }
+};
+
+pub struct BuildEnv {
+    host: &'static str,
+    target: &'static str,
+    target_cpu: Option<&'static str>,
+}
+
+impl BuildEnv {
+    #[expect(unused, reason = "Library code")]
+    pub fn get_host(&self) -> &'static str {
+        self.host
+    }
+
+    pub fn get_target(&self) -> &'static str {
+        self.target
+    }
+
+    pub fn get_target_cpu(&self) -> Option<&str> {
+        self.target_cpu
+    }
+}
+
+pub fn get_build_env() -> BuildEnv {
+    BuildEnv {
+        host: COMPILE_TIME_HOST,
+        target: COMPILE_TIME_TARGET,
+        target_cpu: COMPILE_TIME_TARGET_CPU,
+    }
+}
+
+impl std::fmt::Display for BuildEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Built on `{}`, targeting `{}`", self.host, self.target)?;
+
+        if let Some(target_cpu) = self.target_cpu {
+            write!(f, " (target-cpu `{}`)", target_cpu)?;
+        }
+
+        Ok(())
+    }
+}

--- a/back-end/src/client.rs
+++ b/back-end/src/client.rs
@@ -5,11 +5,11 @@ use tokio::sync::OwnedSemaphorePermit;
 use tracing::{Level, event};
 
 pub struct Client<S> {
-    pub time_spent: Duration,
-    pub send_next: OffsetDateTime,
-    pub bytes_sent: usize,
-    pub addr: SocketAddr,
-    pub tcp_stream: S,
+    time_spent: Duration,
+    send_next: OffsetDateTime,
+    bytes_sent: usize,
+    addr: SocketAddr,
+    tcp_stream: S,
     permit: OwnedSemaphorePermit,
 }
 
@@ -61,6 +61,40 @@ impl<S> Client<S> {
             tcp_stream: stream,
             permit,
         }
+    }
+
+    #[expect(unused, reason = "Consistency with other props")]
+    pub fn time_spent(&self) -> Duration {
+        self.time_spent
+    }
+
+    pub fn time_spent_mut(&mut self) -> &mut Duration {
+        &mut self.time_spent
+    }
+
+    pub fn send_next(&self) -> OffsetDateTime {
+        self.send_next
+    }
+
+    pub fn send_next_mut(&mut self) -> &mut OffsetDateTime {
+        &mut self.send_next
+    }
+
+    #[expect(unused, reason = "Consistency with other props")]
+    pub fn bytes_sent(&self) -> usize {
+        self.bytes_sent
+    }
+
+    pub fn bytes_sent_mut(&mut self) -> &mut usize {
+        &mut self.bytes_sent
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn tcp_stream_mut(&mut self) -> &mut S {
+        &mut self.tcp_stream
     }
 }
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -4,17 +4,13 @@ set -e
 build() {
     APPLICATION_NAME=$1
     PLATFORM=$2
-    docker build \
+    docker buildx \
+        build \
         --file Dockerfile . \
-        --tag $APPLICATION_NAME:latest-${2//\//-} \
+        --tag $APPLICATION_NAME:latest \
         --build-arg APPLICATION_NAME=$APPLICATION_NAME \
         --platform $PLATFORM \
         --progress=plain
 }
 
-name=$(basename ${PWD})
-
-build $name linux/amd64/v3
-build $name linux/amd64/v2
-build $name linux/amd64
-build $name linux/arm64
+build $(basename ${PWD}) linux/amd64/v3,linux/amd64/v2,linux/amd64,linux/arm64

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -25,7 +25,7 @@ case $TARGET in
         ;;
 esac
 
-rust_flags="-Clink-self-contained=yes -Clinker=rust-lld --cfg tokio_unstable ${target_cpu}"
+rustflags="-Clink-self-contained=yes -Clinker=rust-lld --cfg tokio_unstable ${target_cpu}"
 
 # replace - with _ in the Rust target
 target_lower=${TARGET//-/_}
@@ -41,4 +41,4 @@ declare -x "${cxx_var}=${cpp_compiler}"
 cargo_target_linker_var=CARGO_TARGET_${target_upper}_LINKER
 declare -x "${cargo_target_linker_var}=${c_compiler}"
 
-RUSTFLAGS=$rust_flags cargo $@
+RUSTFLAGS=$rustflags cargo $@ --target ${TARGET}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1391,8 +1391,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.243:
-    resolution: {integrity: sha512-ZCphxFW3Q1TVhcgS9blfut1PX8lusVi2SvXQgmEEnK4TCmE1JhH2JkjJN+DNt0pJJwfBri5AROBnz2b/C+YU9g==}
+  electron-to-chromium@1.5.244:
+    resolution: {integrity: sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==}
 
   engine.io-client@6.6.3:
     resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
@@ -4031,7 +4031,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.8.21
       caniuse-lite: 1.0.30001751
-      electron-to-chromium: 1.5.243
+      electron-to-chromium: 1.5.244
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.27.0)
 
@@ -4198,7 +4198,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.243: {}
+  electron-to-chromium@1.5.244: {}
 
   engine.io-client@6.6.3:
     dependencies:


### PR DESCRIPTION
- **fix: regenerate launch.json**
- **fix: regenerate launch.json**
- **chore(deps): update node.js to v24.11.0**
- **chore(deps): update pnpm to v10.20.0**
- **chore(deps): update node.js to v24.11.0**
- **chore(deps): update dependency-cruiser (npm) to v17.2.0**
- **chore(deps): update pnpm to v10.20.0**
- **chore(deps): update node.js to v24.11.0**
- **feat: buildscript to embed targetted platform**
- **chore(deps): update node.js to f36fed0**
- **chore(deps): update vitest monorepo to v4.0.5**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.21.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.21.0**
- **chore(deps): update @eslint/config-helpers (npm) to v0.4.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.141.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.141.1**
- **chore(deps): update github/codeql-action action to v4.31.1**
- **chore(deps): update github/codeql-action action to v4.31.1**
- **chore(deps): update github/codeql-action action to v4.31.2**
- **fix(deps): update rust crate console-subscriber to 0.5.0**
- **fix: string_to_string is deprecated and fails in 1.91.0**
- **chore(deps): update github/codeql-action action to v4.31.2**
- **chore: update lints, keep the ones we allow to allow for tracking new ones**
- **chore: update lints**
- **fix: update build_env**
