### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,15 +552,21 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
           while timeout --kill-after=70 60 docker buildx imagetools create "${new_tags[@]}" \
-            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}; [ $? = 124 ]; do
-            echo "Timeout exceeded, trying again..."
+            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}; [[ ! $? -eq 0 ]]; do
+            echo "Timeout exceeded / command failed, trying again..."
 
             sleep 2
           done
 
+          echo "Process exited with: $?"
+
           for new_tag in $(echo "${{ join(steps.meta.outputs.tags, ' ') }}"); do
             echo "Inspecting ${new_tag}:"
-            docker buildx imagetools inspect --raw ${new_tag}
+            while timeout --kill-after=70 60 docker buildx imagetools inspect --raw ${new_tag}; [[ ! $? -eq 0 ]]; do
+              echo "Timeout exceeded / command failed, trying again..."
+
+              sleep 2
+            done
             # empty to get newline
             echo ""
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "endless-ssh-rs-with-web"
 version = "0.0.0-development"
 edition = "2024"
-rust-version = "1.91.0"
+rust-version = "1.91.1"
 authors = ["Kristof Mattei"]
 description = "endless-ssh-rs in Rust"
 license = "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1387,8 +1387,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.249:
-    resolution: {integrity: sha512-5vcfL3BBe++qZ5kuFhD/p8WOM1N9m3nwvJPULJx+4xf2usSlZFJ0qoNYO2fOX4hi3ocuDcmDobtA+5SFr4OmBg==}
+  electron-to-chromium@1.5.250:
+    resolution: {integrity: sha512-/5UMj9IiGDMOFBnN4i7/Ry5onJrAGSbOGo3s9FEKmwobGq6xw832ccET0CE3CkkMBZ8GJSlUIesZofpyurqDXw==}
 
   engine.io-client@6.6.3:
     resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
@@ -4023,7 +4023,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.8.25
       caniuse-lite: 1.0.30001754
-      electron-to-chromium: 1.5.249
+      electron-to-chromium: 1.5.250
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
@@ -4190,7 +4190,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.249: {}
+  electron-to-chromium@1.5.250: {}
 
   engine.io-client@6.6.3:
     dependencies:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.91.1"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update softprops/action-gh-release action to v2.4.2**
- **chore(deps): update pnpm to v10.21.0**
- **chore(deps): lock file maintenance**
- **fix: more timeout defense**
- **chore(deps): update rust docker tag to v1.91.1**
- **chore(deps): update rust to v1.91.1**
