### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -125,12 +125,25 @@ jobs:
           # append to path
           echo "${temp_path}" >> ${GITHUB_PATH}
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 # v4.5.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set full image name
         shell: bash
@@ -191,5 +204,5 @@ jobs:
         run: |
           echo "${{ steps.meta.outputs.tags }}" | while read new_tag
           do
-            crane cp "${FULL_IMAGE_NAME}:${OLD_TAG}" ${new_tag}
+            docker buildx imagetools create --tag ${new_tag} "${FULL_IMAGE_NAME}:${OLD_TAG}"
           done

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -89,12 +89,25 @@ jobs:
           # append to path
           echo "${temp_path}" >> ${GITHUB_PATH}
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 # v4.5.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set full image name
         shell: bash
@@ -130,5 +143,5 @@ jobs:
         run: |
           echo "${{ steps.meta.outputs.tags }}" | while read new_tag
           do
-            crane cp "${FULL_IMAGE_NAME}:${OLD_TAG}" ${new_tag}
+            docker buildx imagetools create --tag ${new_tag} "${FULL_IMAGE_NAME}:${OLD_TAG}"
           done

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+ignoredBuiltDependencies:
+  - esbuild
+  - unrs-resolver


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.143.1**
- **chore(deps): update dependency-cruiser (npm) to v17.3.1**
- **chore(deps): lock file maintenance**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/checkout action to v5.0.1**
- **chore(deps): update actions/checkout action to v5.0.1**
- **chore(deps): update vitest monorepo to v4.0.10**
- **chore(deps): update typescript-eslint monorepo to v8.47.0**
- **fix: push image with imagetools create**
- **fix: push image with imagetools create**
- **chore: bump packages**
