### PR TITLE
update from upstream

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1379,8 +1379,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.263:
-    resolution: {integrity: sha512-DrqJ11Knd+lo+dv+lltvfMDLU27g14LMdH2b0O3Pio4uk0x+z7OR+JrmyacTPN2M8w3BrZ7/RTwG3R9B7irPlg==}
+  electron-to-chromium@1.5.264:
+    resolution: {integrity: sha512-1tEf0nLgltC3iy9wtlYDlQDc5Rg9lEKVjEmIHJ21rI9OcqkvD45K1oyNIRA4rR1z3LgJ7KeGzEBojVcV6m4qjA==}
 
   engine.io-client@6.6.3:
     resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
@@ -3965,7 +3965,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.9.0
       caniuse-lite: 1.0.30001759
-      electron-to-chromium: 1.5.263
+      electron-to-chromium: 1.5.264
       node-releases: 2.0.27
       update-browserslist-db: 1.2.1(browserslist@4.28.1)
 
@@ -4132,7 +4132,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.263: {}
+  electron-to-chromium@1.5.264: {}
 
   engine.io-client@6.6.3:
     dependencies:


### PR DESCRIPTION
- **chore(deps): update vitest monorepo to v4.0.14**
- **fix(deps): update tokio-tracing monorepo**
- **chore(deps): update prettier (npm) to v3.7.0**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:2-1-bullseye docker digest to 867fc15**
- **chore(deps): update pnpm to v10.24.0**
- **chore(deps): update docker/setup-docker-action action to v4.6.0**
- **chore(deps): update prettier (npm) to v3.7.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/metadata-action action to v5.10.0**
- **fix(deps): update tokio-tracing monorepo**
- **chore(deps): lock file maintenance**
- **chore(deps): update prettier (npm) to v3.7.2**
- **chore(deps): update prettier (npm) to v3.7.3**
- **chore(deps): update dependency-cruiser (npm) to v17.3.2**
- **chore(deps): update vite (npm) to v7.2.6**
- **chore(deps): update softprops/action-gh-release action to v2.5.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v4.31.6**
- **chore(deps): lock file maintenance**
- **fix(deps): update rust crate uuid to 1.19.0**
- **chore(deps): update typescript-eslint monorepo to v8.48.1**
- **chore(deps): update vitest monorepo to v4.0.15**
- **chore(deps): update actions/checkout action to v6.0.1**
- **chore(deps): update actions/setup-node action to v6.1.0**
- **chore(deps): update prettier (npm) to v3.7.4**
- **fix(deps): update react monorepo to v19.2.1**
- **chore(deps): update alpine docker tag to v3.23.0**
- **chore(deps): lock file maintenance**
- **chore: bump packages**
