### PR TITLE
update from upstream

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -142,10 +142,11 @@ rulesets:
           required_status_checks:
             - context: All done
               integration_id: 15368
-            - context: codecov/patch
-              integration_id: 254
-            - context: codecov/project
-              integration_id: 254
+            # These time out too much, we just want the information
+            # - context: codecov/patch
+            #   integration_id: 254
+            # - context: codecov/project
+            #   integration_id: 254
             - context: Format
               integration_id: 15368
             - context: Machete


### PR DESCRIPTION
- **chore(deps): lock file maintenance**
- **chore(deps): update rust:1.93.0-slim-trixie docker digest to 760ad1d**
- **chore(deps): update rust:1.93.0-slim-trixie docker digest to 760ad1d**
- **chore(deps): lock file maintenance**
- **chore(deps): update taiki-e/install-action action to v2.67.22**
- **chore(deps): update taiki-e/install-action action to v2.67.22**
- **chore(deps): lock file maintenance**
- **chore(deps): update taiki-e/install-action action to v2.67.23**
- **chore(deps): update taiki-e/install-action action to v2.67.23**
- **chore(deps): update taiki-e/install-action action to v2.67.24**
- **chore(deps): update taiki-e/install-action action to v2.67.24**
- **chore(deps): lock file maintenance**
- **chore(deps): lock file maintenance**
- **fix: don't wait for codecov, it sometimes blocks**
- **fix: `TARGETARCH` is already the arch, the `//\//-` was for `TARGETPLATFORM`**
- **fix: reorganize crates**
- **chore: bump packages**
