### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install git-cliff to generate changelog & next version number
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: git-cliff
 
@@ -202,7 +202,7 @@ jobs:
           cargo --version
 
       - name: Install cargo-edit to do set-version
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: cargo-edit
 
@@ -373,7 +373,7 @@ jobs:
             type=raw,value=${{ steps.variables.outputs.unique_tag_arch }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47 # v6.19.1
         with:
           build-args: |
             APPLICATION_NAME=${{ needs.docker-prepare-variables.outputs.application_name }}
@@ -589,6 +589,8 @@ jobs:
     # combination of upstream skip and success: success
     runs-on: ubuntu-slim
     needs:
+      - changes
+      - calculate-version
       - docker-prepare-variables
       - rust-build
       - typescript-build

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install cocogitto to lint commits
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: cocogitto
 

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -55,7 +55,7 @@ jobs:
           cargo --version
 
       - name: Install cargo-machete to ensure we don't have unneeded packages
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: cargo-machete
 

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -83,7 +83,7 @@ jobs:
           cargo --version
 
       - name: Install cargo-edit to do set-version
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: cargo-edit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
 
       - name: Install git-cliff to generate changelog & next version number
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: git-cliff
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -192,7 +192,7 @@ jobs:
           rustup update
 
       - name: Install nextest, custom test runner, with native support for junit and grcov
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: cargo-nextest, grcov
 
@@ -230,20 +230,26 @@ jobs:
             --binary-path ./target/debug/ \
             --branch \
             --ignore-not-existing \
-            --keep-only "crates/**/src/**" \
+            --keep-only "crates/**" \
             --llvm \
             --output-path ./reports/lcov.info \
             --output-type lcov \
             --source-dir .
+
+      - name: Record Rust version
+        shell: bash
+        run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"
 
       - name: Upload coverage results (to Codecov.io)
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           disable_search: true
           disable_telem: true
+          env_vars: OS,RUST
           fail_ci_if_error: true
-          flags: ${{ github.job }}
+          flags: back-end
           files: reports/lcov.info
+          name: code-coverage
           plugins: ""
           report_type: "coverage"
           use_oidc: true
@@ -253,9 +259,11 @@ jobs:
         with:
           disable_search: true
           disable_telem: true
+          env_vars: OS,RUST
           fail_ci_if_error: true
-          flags: ${{ github.job }}
+          flags: back-end
           files: reports/results.xml
+          name: test-results
           plugins: ""
           report_type: "test_results"
           use_oidc: true
@@ -306,6 +314,7 @@ jobs:
     # combination of upstream skip and success: success
     runs-on: ubuntu-slim
     needs:
+      - changes
       - cargo-build
       - cargo-clippy-and-report
       - cargo-fmt

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -112,7 +112,7 @@ jobs:
           sudo apt-get install --no-install-recommends --yes libclang-dev
 
       - name: Install cargo-spellcheck to check the spelling
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: cargo-spellcheck@0.15.5
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -40,7 +40,7 @@ jobs:
           show-progress: false
 
       - name: Install git-cliff to generate changelog & next version number
-        uses: taiki-e/install-action@1e67dedb5e3c590e1c9d9272ace46ef689da250d # v2.67.27
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
         with:
           tool: git-cliff
 

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -152,8 +152,9 @@ jobs:
           disable_search: true
           disable_telem: true
           fail_ci_if_error: true
-          flags: ${{ github.job }}
+          flags: front-end
           files: coverage/vitest/lcov.info
+          name: code-coverage
           plugins: ""
           report_type: "coverage"
           use_oidc: true
@@ -164,8 +165,9 @@ jobs:
           disable_search: true
           disable_telem: true
           fail_ci_if_error: true
-          flags: ${{ github.job }}
+          flags: front-end
           files: reports/vitest/test-report.xml
+          name: test-results
           plugins: ""
           report_type: "test_results"
           use_oidc: true

--- a/generate-test-report.sh
+++ b/generate-test-report.sh
@@ -17,8 +17,8 @@ grcov $(find . -name "profile-*.profraw" -print) \
     --binary-path ./target/debug/ \
     --branch \
     --ignore-not-existing \
-    --keep-only "src/**" \
+    --keep-only "crates/**" \
     --llvm \
-    --output-type html \
+    --output-type html,lcov \
     --output-path ./reports/ \
     --source-dir .

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "endless-ssh-rs-with-web",
   "type": "module",
-  "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8",
+  "packageManager": "pnpm@10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc",
   "engines": {
     "node": "24.13.1",
-    "pnpm": "10.29.2"
+    "pnpm": "10.29.3"
   },
   "scripts": {
     "dev": "vite",
@@ -42,7 +42,7 @@
     "@tailwindcss/vite": "4.1.18",
     "@types/eslint": "9.6.1",
     "@types/node": "24.10.13",
-    "@types/react": "19.2.13",
+    "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@typescript-eslint/parser": "8.55.0",
     "@vitejs/plugin-react": "5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,11 +43,11 @@ importers:
         specifier: 24.10.13
         version: 24.10.13
       '@types/react':
-        specifier: 19.2.13
-        version: 19.2.13
+        specifier: 19.2.14
+        version: 19.2.14
       '@types/react-dom':
         specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.13)
+        version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/parser':
         specifier: 8.55.0
         version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -945,8 +945,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.13':
-    resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@typescript-eslint/eslint-plugin@8.55.0':
     resolution: {integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==}
@@ -3635,11 +3635,11 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/react-dom@19.2.3(@types/react@19.2.13)':
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
-      '@types/react': 19.2.13
+      '@types/react': 19.2.14
 
-  '@types/react@19.2.13':
+  '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
 


### PR DESCRIPTION
- **chore(deps): update taiki-e/install-action action to v2.67.28**
- **chore(deps): lock file maintenance**
- **chore(deps): update taiki-e/install-action action to v2.67.28**
- **chore(deps): update @types/react (npm) to v19.2.14**
- **chore(deps): update docker/build-push-action action to v6.19.0**
- **chore(deps): update docker/build-push-action action to v6.19.0**
- **chore(deps): update pnpm to v10.29.3**
- **chore(deps): update pnpm to v10.29.3**
- **chore(deps): update docker/build-push-action action to v6.19.1**
- **fix: ensure the build fails when the detect changes task fails**
- **fix: also depend on calculate-version**
- **fix: add `env_vars`, set name**
- **chore(deps): update docker/build-push-action action to v6.19.1**
- **fix: disable flags when not needed**
- **fix: set flags**
